### PR TITLE
chore: no more prefligth request

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -1,4 +1,5 @@
 export function middleware(req, res) {
-    console.log('-------INVOKE-MIDDLEWARE-------')
-    console.log({"MIDDLEWARE: Request Method:":req.method})
+  console.log("-------INVOKE-MIDDLEWARE-------");
+  console.log({ "MIDDLEWARE: Request Method:": req.method });
+  console.log({ "MIDDLEWARE: Requested URL:": req.nextUrl.pathname });
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "^12.1.7-canary.23",
+    "next": "latest@canary",
     "react": "18.0.0",
     "react-dom": "18.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,10 +46,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@next/env@12.1.7-canary.23":
-  version "12.1.7-canary.23"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-12.1.7-canary.23.tgz#bf6527bd24448449432ba6451ec603f0a81049a2"
-  integrity sha512-EKVoeIrvYrTK4xOlIIP3EMXZAltVN8QmJ6G8f/Oiuoyy+KdKyeHQRlOyxqFzxLwTgzDLnmm1gCcmvAlf9A10hQ==
+"@next/env@12.1.7-canary.41":
+  version "12.1.7-canary.41"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-12.1.7-canary.41.tgz#8a24643278f5941b78b1886040554d98f06be0c4"
+  integrity sha512-VmZeXwRgy58ed087xcH85r/1sRU2tWZnX/rOC7QkbQd3zIcA0IksUyNmjTmSuqyo+W1Vx1vh3wNC9MT4XOvsSQ==
 
 "@next/eslint-plugin-next@12.1.4":
   version "12.1.4"
@@ -58,70 +58,70 @@
   dependencies:
     glob "7.1.7"
 
-"@next/swc-android-arm-eabi@12.1.7-canary.23":
-  version "12.1.7-canary.23"
-  resolved "https://registry.yarnpkg.com/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.1.7-canary.23.tgz#6cdd178a6b8d31a1624a8e132fd2a584b219edab"
-  integrity sha512-OSz3g6p6c/U1t7Ve6fzP4zn32I6JJNcgWGemYRm7MFx05lu0YhVnRNGPzN2OEtAiF4WBok0r79sY+BOvvpDcBQ==
+"@next/swc-android-arm-eabi@12.1.7-canary.41":
+  version "12.1.7-canary.41"
+  resolved "https://registry.yarnpkg.com/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.1.7-canary.41.tgz#9d36144f5c57d7a6a902bc9012b748e2d0581306"
+  integrity sha512-OLVt2Xkeu4QAFrGZd+EvYG2ncMp90dzekUN8/RWFGqH7zkCS1We1NW6gOAeXPSV9cevBKFmzHESDddwLuY99hA==
 
-"@next/swc-android-arm64@12.1.7-canary.23":
-  version "12.1.7-canary.23"
-  resolved "https://registry.yarnpkg.com/@next/swc-android-arm64/-/swc-android-arm64-12.1.7-canary.23.tgz#536c00e2cdf330e00c174c25d0bd4673ac8b9183"
-  integrity sha512-WuS/4e8+PE/0l6EHl5cUNN4JDgYaoDEmD80sMiU+vzISMgArnJAOm/u/1hzhww5O5w7zdieLXTnOJo0nd1LRNg==
+"@next/swc-android-arm64@12.1.7-canary.41":
+  version "12.1.7-canary.41"
+  resolved "https://registry.yarnpkg.com/@next/swc-android-arm64/-/swc-android-arm64-12.1.7-canary.41.tgz#1121850e70ef2806014f369b9865372dedd46dbd"
+  integrity sha512-aEad5fRVR8Wse2gQZtFmKk/xQpJPc8cc8d/lTsOzx9aRwhsnK/9vwYy+RIQlXG6W9zzDnwD7icS0UNjgktLeeA==
 
-"@next/swc-darwin-arm64@12.1.7-canary.23":
-  version "12.1.7-canary.23"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.7-canary.23.tgz#beb461aa69f8270ca924c106b60e7b97d62d07d4"
-  integrity sha512-1rd6Oj1bo7FUdAW5rL7yX97suXnrEuQoO8J6oezV4Q4jECaGpTg68J6FvoAb1Hu73b9/ErHrlYXXVoF9OZVxmQ==
+"@next/swc-darwin-arm64@12.1.7-canary.41":
+  version "12.1.7-canary.41"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.7-canary.41.tgz#9dd8c4d478ff090823d652fb2731422e336a2826"
+  integrity sha512-w9V3QVGzxzX8DnleyD8PYKt3Ed6v50H6t1zY+kPUKPhH1jMd7tZqZiShzhOeCLMnGxit0VeHlOqz785jhEcwTg==
 
-"@next/swc-darwin-x64@12.1.7-canary.23":
-  version "12.1.7-canary.23"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.7-canary.23.tgz#fee3bc1d28cfce8795569655f09b9f8f6e5e78d7"
-  integrity sha512-l97PDBpEadxZv6Qotd0WI99BxKEO3fKneVxNXg4bpf9McKXERi6eaAZvUWlNFMavcwssmX1ez5zNPrvcHP47pQ==
+"@next/swc-darwin-x64@12.1.7-canary.41":
+  version "12.1.7-canary.41"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.7-canary.41.tgz#4b7e029475c2989e331332d00f6974f06acb0847"
+  integrity sha512-LuBPGtd0sJdHJWW+R77NgzkuW8S4SvPqMF/FREl1qV2Q7qPsx206rKBMdOMIowwPy9UJv7uePGK6kW2lLnE1pg==
 
-"@next/swc-freebsd-x64@12.1.7-canary.23":
-  version "12.1.7-canary.23"
-  resolved "https://registry.yarnpkg.com/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.1.7-canary.23.tgz#0ab0d75122d7093dbb5b15260f645c398ec5f536"
-  integrity sha512-HB9bkQ2AqXFMxe9lhZMPG+ZWKGtDxc2563UmuURX8VByHN0I7GrZEj64ThtE59ioVsT+rOPzcZrlZCbQBFhpyA==
+"@next/swc-freebsd-x64@12.1.7-canary.41":
+  version "12.1.7-canary.41"
+  resolved "https://registry.yarnpkg.com/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.1.7-canary.41.tgz#1fe2455a8ce9ff57efa69a76ca510e1df8bf7f30"
+  integrity sha512-HxeyoCVCswc/ElsmzfY85g3KRbuwR9c70ICfJcQJMFkhPvtxMKdWo2m42EnvX0ZJJuv4xbU/+MxxssSnWwgrlg==
 
-"@next/swc-linux-arm-gnueabihf@12.1.7-canary.23":
-  version "12.1.7-canary.23"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.7-canary.23.tgz#95ee61abf14db469a6d64b8834004be84c003464"
-  integrity sha512-YRhlxl++AyXcvh0AWr9AkUJUJIkufxnMTUzIAmeOpCObIs6ymXb1MMBxeMJrVm7aV2V09txdff0cIvED/iJFng==
+"@next/swc-linux-arm-gnueabihf@12.1.7-canary.41":
+  version "12.1.7-canary.41"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.7-canary.41.tgz#63b00d20fa0aca370ce934fd98c6ecc9b054fac5"
+  integrity sha512-6ga3RM0fja7jRJlxpYd154eUhB+vfjF7OlMfc/S7FOT6Ks7ti3eGp9nsW0JQ5LFNcyE5lVe6ICKHVCGUaGAS1g==
 
-"@next/swc-linux-arm64-gnu@12.1.7-canary.23":
-  version "12.1.7-canary.23"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.7-canary.23.tgz#d3500729c812a48676d8dc9b14dcd5b3ee4a5a3f"
-  integrity sha512-4MLGUmfwu0/wAvTgvXXLD2DNMyhdBiN0QQoFw0cS1eWAZVCuv72QipNZ+6oTN7Ae7o/qES5Oi+vlBDdnEwRmDg==
+"@next/swc-linux-arm64-gnu@12.1.7-canary.41":
+  version "12.1.7-canary.41"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.7-canary.41.tgz#aca014c8341ff33d87bd596e0fc7fbadf02ce5a9"
+  integrity sha512-AFyMzqvzoRT80IavAhyN5iJLvM6RTkKsxVic/U857qCe6q2FAKD0m6V6GK35PTv8kDqOG3PH5VykfYsHDBpKKQ==
 
-"@next/swc-linux-arm64-musl@12.1.7-canary.23":
-  version "12.1.7-canary.23"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.7-canary.23.tgz#ec52eb8b50091bd12d6f252501cc8157fe904228"
-  integrity sha512-4iOVzAo2AdCYTEvObJYWYOyagMGe0WWjcBrv1GJ4obJ3qIxSg4lbhoZZuOGv3xYQKdU4ZgXHceZinRqxgGYAiw==
+"@next/swc-linux-arm64-musl@12.1.7-canary.41":
+  version "12.1.7-canary.41"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.7-canary.41.tgz#82f80f815ab3d308598d7f28f3785da0a43a2b3b"
+  integrity sha512-/DMYC6iGYgkQGUid1qBmRRkAoonVIF5VMYjaK/apBhUdWNBqpa/jNCpn/NQs2NOL8QnnMx4wMGxNIOBm2AGOPQ==
 
-"@next/swc-linux-x64-gnu@12.1.7-canary.23":
-  version "12.1.7-canary.23"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.7-canary.23.tgz#67dc25ff595c2dd14682f109d943507ebfe0b944"
-  integrity sha512-6DLsKEKuPkknp1yuvPpE18n10Y9N0shHDQWjPPQFKqZqvz7px3O8EUF6EB1KR1PRR7xwcLoWLf33N2s/Sr8rFQ==
+"@next/swc-linux-x64-gnu@12.1.7-canary.41":
+  version "12.1.7-canary.41"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.7-canary.41.tgz#bf46ccbd609def43d46a3612ec176919e0cb3852"
+  integrity sha512-qwHN5j2kT11F+xJSwMIeZPqNgfzM2tmfhNf5ruU/erf5RU90gr5+jcfbKQzuL5grj9PnrRkfKTH9Rms2GNrx+g==
 
-"@next/swc-linux-x64-musl@12.1.7-canary.23":
-  version "12.1.7-canary.23"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.7-canary.23.tgz#c8acd44b8f62fa56caf5bb4be065aa4a71842d1e"
-  integrity sha512-2EORnA604df14DxwYmvZ5DK0JE+lCk5kEAjGIAmvIW2R5DNB93wQ+RjrKn5fsKpyB/HqKRZjgC5zLeqMTP91OQ==
+"@next/swc-linux-x64-musl@12.1.7-canary.41":
+  version "12.1.7-canary.41"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.7-canary.41.tgz#4a4342a314455c120b1c103ad4bde7099b1fcc93"
+  integrity sha512-rlyRorqisG0rtPKQM1kNC/mYNRSCPFaDCaB+hzTfVmfBNWZYktKYLhImHc36TSr90HO5ZOPIH2fXxAt/bEOMaA==
 
-"@next/swc-win32-arm64-msvc@12.1.7-canary.23":
-  version "12.1.7-canary.23"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.7-canary.23.tgz#3f100bfd6a489093e350beaf3784b21e11e75bb9"
-  integrity sha512-BXVJ/1NTBeOpoeNVM7aTxY2LG0a1frjn7XynSeObLo8V8RAj33rJdAzQm2wSF2DbpfC3PFBjmvzajfcVqrwiWQ==
+"@next/swc-win32-arm64-msvc@12.1.7-canary.41":
+  version "12.1.7-canary.41"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.7-canary.41.tgz#1d76016ed1d9a911a86fef9bec34085729835ef0"
+  integrity sha512-vpxjL2KVuXLE6g2wqbH5hK1SF2rZjOq0XgaBov1TN069BkeZ6yfAHe2VTBBe6XkYjhbKiCNGoei/+YD1GZITzw==
 
-"@next/swc-win32-ia32-msvc@12.1.7-canary.23":
-  version "12.1.7-canary.23"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.7-canary.23.tgz#0a61911760912ccf4570d777ee090d5811807986"
-  integrity sha512-/nJXWnCobRfIRgrCGmkHmdqAfiG1S9jKRY06Ene44XI0j7lzb5DBXPFELK7zuZuBDriZALvpaejv6E4wLP+pnQ==
+"@next/swc-win32-ia32-msvc@12.1.7-canary.41":
+  version "12.1.7-canary.41"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.7-canary.41.tgz#2b1d056b0442722bf89b9b9b6983609f9ea9a115"
+  integrity sha512-uOq/vK7njl0Fn9l87g4tKTPiSu7vrAIroPQQdO1vcuZ5cn/DGYcYh2JE9akq8bLVWMuhtc+LxnS62yQc5cJpPA==
 
-"@next/swc-win32-x64-msvc@12.1.7-canary.23":
-  version "12.1.7-canary.23"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.7-canary.23.tgz#674da3aa072b56aab1aaa3aab3f0e73968f857bc"
-  integrity sha512-GV9QRyYt9qLKya3W7cvJscfYVyytmgUn1N3CKDRhDc2VU4H7w1cE5sexPVNuAoxYAW6RoViXHcEQUrwp2z2X0A==
+"@next/swc-win32-x64-msvc@12.1.7-canary.41":
+  version "12.1.7-canary.41"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.7-canary.41.tgz#67dca62a8e391680ed100b35bd98de3ae3c782cc"
+  integrity sha512-E3kleIYKF9aOU7K208ZJ5A7R9ELiS+3Ax6xOdM/wj9zez5jChgT5BCIY4UNJx1VzLOycREP3Y7gCEQGQY6SAxg==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -148,6 +148,13 @@
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.0.8.tgz#be3e914e84eacf16dbebd311c0d0b44aa1174c64"
   integrity sha512-ZK5v4bJwgXldAUA8r3q9YKfCwOqoHTK/ZqRjSeRXQrBXWouoPnS4MQtgC4AXGiiBuUu5wxrRgTlv0ktmM4P1Aw==
+
+"@swc/helpers@0.3.17":
+  version "0.3.17"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.3.17.tgz#7c1b91f43c77e2bba99492162a498d465ef253d5"
+  integrity sha512-tb7Iu+oZ+zWJZ3HJqwx8oNwSDIU440hmVMDPhpACWQWnrZHK99Bxs70gT1L2dnr5Hg50ZRWEFkQCAnOVVV0z1Q==
+  dependencies:
+    tslib "^2.4.0"
 
 "@types/json5@^0.0.29":
   version "0.0.29"
@@ -1182,30 +1189,31 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-next@^12.1.7-canary.23:
-  version "12.1.7-canary.23"
-  resolved "https://registry.yarnpkg.com/next/-/next-12.1.7-canary.23.tgz#6a638dbfba4871c32e8bd2bb38515c58118d83da"
-  integrity sha512-ey+hj7RCsKe+idmpaQb/vxVY0/hzYpquOPvTyIQVdaerHMtlfcxPe84QlG7eoXj5d8OhIkF7NPqTqMeJP707PA==
+next@latest@canary:
+  version "12.1.7-canary.41"
+  resolved "https://registry.yarnpkg.com/next/-/next-12.1.7-canary.41.tgz#21280e3c8dc2694194a5837a7e8db54042f656ad"
+  integrity sha512-+Rt2Rr/E4kBubMxK/83+ZnL/Vvroi7cjDhxJGjthUi7CJK8Y8QCKM2pb+8Cn7nEWLHBPkTjV121YUlIij03s2A==
   dependencies:
-    "@next/env" "12.1.7-canary.23"
+    "@next/env" "12.1.7-canary.41"
+    "@swc/helpers" "0.3.17"
     caniuse-lite "^1.0.30001332"
     postcss "8.4.5"
     styled-jsx "5.0.2"
     use-sync-external-store "1.1.0"
   optionalDependencies:
-    "@next/swc-android-arm-eabi" "12.1.7-canary.23"
-    "@next/swc-android-arm64" "12.1.7-canary.23"
-    "@next/swc-darwin-arm64" "12.1.7-canary.23"
-    "@next/swc-darwin-x64" "12.1.7-canary.23"
-    "@next/swc-freebsd-x64" "12.1.7-canary.23"
-    "@next/swc-linux-arm-gnueabihf" "12.1.7-canary.23"
-    "@next/swc-linux-arm64-gnu" "12.1.7-canary.23"
-    "@next/swc-linux-arm64-musl" "12.1.7-canary.23"
-    "@next/swc-linux-x64-gnu" "12.1.7-canary.23"
-    "@next/swc-linux-x64-musl" "12.1.7-canary.23"
-    "@next/swc-win32-arm64-msvc" "12.1.7-canary.23"
-    "@next/swc-win32-ia32-msvc" "12.1.7-canary.23"
-    "@next/swc-win32-x64-msvc" "12.1.7-canary.23"
+    "@next/swc-android-arm-eabi" "12.1.7-canary.41"
+    "@next/swc-android-arm64" "12.1.7-canary.41"
+    "@next/swc-darwin-arm64" "12.1.7-canary.41"
+    "@next/swc-darwin-x64" "12.1.7-canary.41"
+    "@next/swc-freebsd-x64" "12.1.7-canary.41"
+    "@next/swc-linux-arm-gnueabihf" "12.1.7-canary.41"
+    "@next/swc-linux-arm64-gnu" "12.1.7-canary.41"
+    "@next/swc-linux-arm64-musl" "12.1.7-canary.41"
+    "@next/swc-linux-x64-gnu" "12.1.7-canary.41"
+    "@next/swc-linux-x64-musl" "12.1.7-canary.41"
+    "@next/swc-win32-arm64-msvc" "12.1.7-canary.41"
+    "@next/swc-win32-ia32-msvc" "12.1.7-canary.41"
+    "@next/swc-win32-x64-msvc" "12.1.7-canary.41"
 
 object-assign@^4.1.1:
   version "4.1.1"
@@ -1602,6 +1610,11 @@ tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
Hello @maxrawlinger 
This small PR should hopefully demonstrate:
1. the absence of `HEAD` request with latest canary
2. why there are so many calls: I put the url to illustrate that middleware is invoked on static assets

In order to restrict your middleware to a subset of routes, you can use [configuration matcher](https://nextjs.org/docs/messages/middleware-upgrade-guide#how-to-upgrade):
```js
export const config = {
  matcher: ['/about/:path*', '/dashboard/:path*'],
}
```
